### PR TITLE
README.md: link to official HomeBrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ auth     sufficient   pam_tid.so
 For further information, see `reattach_aqua(3)`, `pam_reattach(8)` and `reattach-to-session-namespace(8)`.
 
 ## Installation
-The module is available in my personal Homebrew repository. Use the following
-command to install it:
+The module is available via Homebrew. Use the following command to install it:
 
 ```bash
-$ brew install fabianishere/personal/pam_reattach
+$ brew install pam-reattach
 ```
 
 You can also install this module with MacPorts using the following command:


### PR DESCRIPTION
Just noticed an official formula now exists (and it might benefit from upstream CI, bottling, etc.), so I thought you might want to update the README. To wit:

```
$ brew info pam-reattach
pam-reattach: stable 1.2 (bottled), HEAD
PAM module for reattaching to the user's GUI (Aqua) session
https://github.com/fabianishere/pam_reattach
/opt/homebrew/Cellar/pam-reattach/1.2 (11 files, 97.9KB) *
  Poured from bottle on 2021-12-24 at 20:07:52
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/pam-reattach.rb
License: MIT
==> Dependencies
Build: cmake ✔
==> Requirements
Required: macOS ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 26 (30 days), 26 (90 days), 26 (365 days)
install-on-request: 26 (30 days), 26 (90 days), 26 (365 days)
build-error: 0 (30 days)
```