### PR TITLE
Add detection of likely SSH sessions and default-off behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
 install_manifest.txt
+compile_commands.json
+
+.cache

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ auth     optional     /opt/homebrew/lib/pam/pam_reattach.so
 auth     sufficient   pam_tid.so
 ...
 ```
+
+By default, this module will skip reattaching when the environment indicates a probable login via SSH. This is detected by the presence of any one of `$SSH_CLIENT`, `$SSH_CONNECTION`, and `$SSH_TTY`. To skip this behavior, the option `allow_ssh` can be added to the module line in your PAM configuration as shown:
+```
+auth     optional     pam_reattach.so allow_ssh
+auth     sufficient   pam_tid.so
+...
+```
 For further information, see `reattach_aqua(3)`, `pam_reattach(8)` and `reattach-to-session-namespace(8)`.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ auth     sufficient   pam_tid.so
 ...
 ```
 
-By default, this module will skip reattaching when the environment indicates a probable login via SSH. This is detected by the presence of any one of `$SSH_CLIENT`, `$SSH_CONNECTION`, and `$SSH_TTY`. To skip this behavior, the option `allow_ssh` can be added to the module line in your PAM configuration as shown:
+The `pam_tid` module will try to avoid prompting for a touch when connected via SSH or another remote login method. However, there are situations (e.g. use of tmux and screen) where the current tty may be spawned by a remote session but not detected as such by `pam_tid`. To help mitigate this, the `ignore_ssh` option can be added to the configuration of `pam_reattach` as follows:
 ```
-auth     optional     pam_reattach.so allow_ssh
+auth     optional     pam_reattach.so ignore_ssh
 auth     sufficient   pam_tid.so
 ...
 ```
+This will detect the presence of any of `$SSH_CLIENT`, `$SSH_CONNECTION`, or `$SSH_TTY` in the environment, and cause this module to become a no-op.
+
 For further information, see `reattach_aqua(3)`, `pam_reattach(8)` and `reattach-to-session-namespace(8)`.
 
 ## Installation

--- a/man/pam_reattach.8
+++ b/man/pam_reattach.8
@@ -20,7 +20,7 @@
 .\" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 .\" OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 .\" THE SOFTWARE.
-.Dd August 14, 2018
+.Dd May 6, 2022
 .Dt pam_reattach 8
 .Os
 .Sh NAME
@@ -35,6 +35,17 @@ pam_reattach
 .Sh DESCRIPTION
 The reattach authentication module is used to move the next authentication
 modules to the correct, per-session, bootstrap namespace.
+
+The following options may be passed to this authentication module:
+.Bl -tag -width ".Cm default_principal"
+.It Cm allow_ssh
+Disable detection of probable SSH sessions. By default this module will be
+becom a no-op when one of
+.Dv $SSH_CLIENT,
+.Dv $SSH_CONNECTION,
+or
+.Dv $SSH_TTY
+is detected in the environment.
 .Sh SEE ALSO
 .Xr pam.conf 5 ,
 .Xr pam 8

--- a/man/pam_reattach.8
+++ b/man/pam_reattach.8
@@ -38,14 +38,16 @@ modules to the correct, per-session, bootstrap namespace.
 
 The following options may be passed to this authentication module:
 .Bl -tag -width ".Cm default_principal"
-.It Cm allow_ssh
-Disable detection of probable SSH sessions. By default this module will be
-becom a no-op when one of
-.Dv $SSH_CLIENT,
-.Dv $SSH_CONNECTION,
+.It Cm ignore_ssh
+Detect and ignore probable SSH sessions. This helps prevent erroneously
+prompting for a touch when SSH and a terminal multiplexer like 
+.Xr tmux 1
+is in use. This detection is based on the presence of
+.Dv $SSH_CLIENT ,
+.Dv $SSH_CONNECTION ,
 or
 .Dv $SSH_TTY
-is detected in the environment.
+in the environment.
 .Sh SEE ALSO
 .Xr pam.conf 5 ,
 .Xr pam 8

--- a/src/pam.c
+++ b/src/pam.c
@@ -46,8 +46,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv)
 	struct passwd pwdbuf;
 	uid_t uid;
 
-	/* Ignore probable SSH sessions unless configured otherwise */
-	if (!openpam_get_option(pamh, "allow_ssh")) {
+	/* Ignore probable SSH sessions when configured */
+	if (openpam_get_option(pamh, "ignore_ssh")) {
 		for (i = 0; i < sizeof(ssh_env_vars); i++) {
 			if ((env = getenv(ssh_env_vars[i])) != NULL && strlen(env)) {
 				openpam_log(PAM_LOG_ERROR, "Skipping pam_reattach because $%s is present", ssh_env_vars[i]);

--- a/src/pam.c
+++ b/src/pam.c
@@ -84,3 +84,6 @@ pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv)
 	return PAM_IGNORE;
 }
 
+#ifdef PAM_MODULE_ENTRY
+PAM_MODULE_ENTRY("pam_reattach");
+#endif


### PR DESCRIPTION
A new `allow_ssh` option is added for those that prefer the previous behavior. This new behavior is advantageous as it avoids requiring Touch ID for use of sudo over SSH, where physical proximity is not guaranteed (or even likely).
