### PR TITLE
Add Hint to find PAM library

### DIFF
--- a/cmake/Modules/FindPAM.cmake
+++ b/cmake/Modules/FindPAM.cmake
@@ -8,7 +8,10 @@ find_path(PAM_INCLUDE_DIR security/pam_modules.h PATH_SUFFIXES ..)
 
 set(PAM_DEFINITIONS "-fPIC")
 
-find_library(PAM_LIBRARY NAMES pam)
+find_library(PAM_LIBRARY
+    NAMES pam
+    HINTS /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/
+)
 
 set(PAM_LIBRARIES ${PAM_LIBRARY})
 set(PAM_INCLUDE_DIRS ${PAM_INCLUDE_DIR})
@@ -24,4 +27,3 @@ mark_as_advanced(PAM_INCLUDE_DIR PAM_LIBRARY)
 add_library(pam SHARED IMPORTED GLOBAL)
 set_property(TARGET pam PROPERTY IMPORTED_LOCATION ${PAM_LIBRARY})
 set_property(TARGET pam PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PAM_INCLUDE_DIRS})
-


### PR DESCRIPTION
I tried building the module on a freshly setup Mac and always got the error:
```
-- The C compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- pam include dir: /nix/store/w864nsavm6gm97aqy5654dc1dppg7fw8-libSystem-11.0.0/include
-- pam lib: PAM_LIBRARY-NOTFOUND
CMake Error at /nix/store/rwvkqq6rs4xxxvkh6fpgxp329yr82l5m-cmake-3.22.3/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PAM (missing: PAM_LIBRARY)
Call Stack (most recent call first):
  /nix/store/rwvkqq6rs4xxxvkh6fpgxp329yr82l5m-cmake-3.22.3/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindPAM.cmake:22 (find_package_handle_standard_args)
  CMakeLists.txt:26 (find_package)


-- Configuring incomplete, errors occurred!
See also "/tmp/pam_reattach/CMakeFiles/CMakeOutput.log".
```

(checked out the repo in `/tmp/pam_reattach`).

As you can see, I'm also using Nix, which might cause the issue (?) and is also the reason why I'm not using `brew`.

I'm no sure if it makes sense to merge it like this or not, but I figured I'd open a PR and hear whether this makes sense to you. 

Disclaimer: I have no idea what I'm doing, never really used CMake or built C programs before :-)

But with the supplied patch everything worked as expected.